### PR TITLE
Add paginated IAM scanner and Flask web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,62 @@
 # AWS IAM Permissions Scan
 
-This tool lists all policies assigned to all IAM users in your AWS account. Policies can be assigned to users via user policies or inherited by group memberships. 
+This project scans AWS IAM permissions assigned to users directly and through group membership.
 
-Read only permissions to IAM in the AWS account being scanned are required. This can be achieved by assigning the SecurityAudit AWS Managed policy to the IAM user or role being used to run this scan. 
+## What's improved
 
-There are existing tools that go through potential privilege escalation avenues due to excessive AWS permissions. This script therefore complements rather than replaces some of these tools, such as Rhino Security's [AWS Escalate](https://github.com/RhinoSecurityLabs/Security-Research/blob/master/tools/aws-pentest-tools/aws_escalate.py), NCC Group's [Scout2](https://github.com/nccgroup/Scout2), or [CloudSploit](https://github.com/cloudsploit).
+- **Reliable pagination support** for IAM list APIs, including:
+  - `get_account_authorization_details` for full user/group collection
+  - `list_user_policies` for full inline policy name collection
+- **Refactored scanner engine** (`scanner.py`) reusable from both CLI and web app.
+- **Web GUI** using Flask for running scans from a browser.
 
-## Getting Started
+## Requirements
 
-This script requires Python 3
+- Python 3.10+
+- AWS credentials configured locally (for example via `aws configure`)
+- IAM read permissions (for example, AWS managed policy `SecurityAudit`)
 
-Install the AWS Python SDK and Dependencies. [Details](https://github.com/boto/boto3)
+Install dependencies:
 
-Install [Colorama](https://pypi.org/project/colorama/)
-
-The requirements.txt file can be used to install the dependencies using pip3
-
- ```
- pip3 install -r requirements.txt
- ```
-
-Further details can be found [here](https://aws.amazon.com/developers/getting-started/python/)
-
-Setup your AWS credentials. If you have awscli installed, running `aws configure` will prompt you for your AWS Access Key ID and your Secret Key, and create the `~/.aws/credentials` file. Alternatively, the `~/.aws/credentials` file can be configured as shown in the below example:
-
-```
-[default]
-aws_access_key_id = AWS_KEY
-aws_secret_access_key = AWS_SECRET
+```bash
+pip3 install -r requirements.txt
 ```
 
-If you need to assume an IAM role and then scan for assigned permissions, remind101's assume-role tool is very helpful, especially is you are required to provide MFA. [Link](https://github.com/remind101/assume-role)
+## CLI Usage
 
+Run pretty text output:
 
-### Running
-
+```bash
+python aws_perms.py
 ```
-python ./aws_perms.py
+
+Run JSON output:
+
+```bash
+python aws_perms.py --json
 ```
+
+Use a specific AWS profile:
+
+```bash
+python aws_perms.py --profile my-profile
+```
+
+## Web App Usage
+
+Start the web app:
+
+```bash
+python app.py
+```
+
+Then open:
+
+- `http://127.0.0.1:5000`
+
+Enter an optional AWS profile and click **Run Scan**.
+
+## Notes
+
+- IAM is a global service; region is optional and mainly present for session compatibility.
+- Managed policy statements can be large depending on your account's policy set.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,26 @@
+from flask import Flask, render_template, request
+
+from scanner import IAMScanner
+
+app = Flask(__name__)
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    report = None
+    error = None
+    profile = ""
+
+    if request.method == "POST":
+        profile = request.form.get("profile", "").strip()
+        try:
+            scanner = IAMScanner(profile=profile or None)
+            report = scanner.scan()
+        except Exception as exc:  # noqa: BLE001
+            error = str(exc)
+
+    return render_template("index.html", report=report, error=error, profile=profile)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/aws_perms.py
+++ b/aws_perms.py
@@ -1,140 +1,58 @@
-import boto3
-import pprint
-from colorama import Fore, Back, Style
+import argparse
+import json
 
-def iam_get_account_details():
-    client = boto3.client('iam')
-    response = client.get_account_authorization_details()
-    return response
+from colorama import Fore, Style, init
 
-def iam_list_users():
-    client = boto3.client('iam')
-    users = client.list_users()
-    return users  
+from scanner import IAMScanner
 
 
-client = boto3.client('iam')
-paginator = client.get_paginator('get_account_authorization_details')
+def print_scan(report: dict) -> None:
+    for user in report["users"]:
+        print(Fore.BLUE + f"User Name: {user['user_name']}" + Style.RESET_ALL)
 
-userList = list(paginator.paginate(Filter=['User']))
-if userList[0]['IsTruncated'] == True:                  #TODO: need to properly handle truncated results
-    print(Fore.RED+ "Truncated User List" + Fore.RESET)
-groupList = list(paginator.paginate(Filter=['Group']))
-if groupList[0]['IsTruncated'] == True:
-    print(Fore.RED+ "Truncated Group List" + Fore.RESET)
+        if not user["inline_policies"]:
+            print(Fore.GREEN + " - No inline policies" + Style.RESET_ALL)
+        else:
+            print(" - User inline policies:")
+            for policy in user["inline_policies"]:
+                print(Fore.CYAN + f"   + {policy['name']}" + Style.RESET_ALL)
+                for statement in policy["statements"]:
+                    print(f"     Effect: {statement.get('effect')}")
+                    for action in statement.get("actions", []):
+                        print(f"       Action: {action}")
+
+        if not user["managed_policies"]:
+            print(Fore.GREEN + " - No managed policies" + Style.RESET_ALL)
+        else:
+            print(" - User managed policies:")
+            for policy in user["managed_policies"]:
+                print(Fore.CYAN + f"   + {policy['name']} ({policy['arn']})" + Style.RESET_ALL)
+
+        if not user["groups"]:
+            print(Fore.GREEN + " - No group membership" + Style.RESET_ALL)
+        else:
+            print(" - Groups:")
+            for group in user["groups"]:
+                print(Fore.MAGENTA + f"   + {group['name']}" + Style.RESET_ALL)
+
+        print()
 
 
-for user in userList[0]['UserDetailList']:
-    user_inline_policies = client.list_user_policies(UserName=user['UserName'])
-    if user_inline_policies['IsTruncated'] == True:
-        print(Fore.RED + "Truncated Inline Policies" + Fore.RESET)      # Prints whether or not results are truncated.
-    
-    #Get user inline policies
-    print(Fore.BLUE + "User Name: ", user['UserName'] + Fore.RESET)     # Prints Username
-    if len(user_inline_policies['PolicyNames']) == 0:
-        print(Fore.LIGHTGREEN_EX +" - No Inline Policies found for", user['UserName'] + Fore.RESET)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scan IAM permissions for all account users")
+    parser.add_argument("--profile", help="AWS profile name", default=None)
+    parser.add_argument("--region", help="AWS region (IAM is global, optional)", default=None)
+    parser.add_argument("--json", action="store_true", help="Print JSON output")
+    args = parser.parse_args()
+
+    init(autoreset=True)
+    report = IAMScanner(profile=args.profile, region=args.region).scan()
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
     else:
-        print(" - User Inline Policies: ", user_inline_policies['PolicyNames'])
-        for user_inline_policy in user_inline_policies['PolicyNames']:
-            inline_policy_document = client.get_user_policy(UserName=user['UserName'],PolicyName=user_inline_policy)
-            print("           + Policy Statement for Inline Policy:" , Fore.LIGHTBLUE_EX + user_inline_policy + Fore.RESET)
-            inline_policy_statement = inline_policy_document['PolicyDocument']['Statement']
-            if type(inline_policy_statement) == type(dict()):
-                for key,value in inline_policy_statement.items():   
-                    if key == 'Action':                   #Prints all actions in separate lines
-                        for j in inline_policy_statement['Action']:
-                            print("              ", key, ":", j)
-                    else:
-                        print("              ", key, ":", value)      #Print all elements within the statement dictionary
-            else:
-                for statement in inline_policy_statement:       
-                    for key,value in statement.items():      
-                        print("              ", key, ":", value)
-            print("\n", end="")
+        print_scan(report)
 
-    #Get user managed policies        
-    user_managed_policies = user.get('AttachedManagedPolicies')
-    if len(user_managed_policies) == 0:
-        print(Fore.LIGHTGREEN_EX +" - No Managed Policies found for", user['UserName'] + Fore.RESET)
-    else:
-        print(" - User Managed Policies:")
-        for policy in user_managed_policies:
-            user_managed_policy_arn = policy['PolicyArn']
-            user_managed_policy_name = policy['PolicyName']
-            user_managed_policy_details = client.get_policy(PolicyArn=user_managed_policy_arn)
-            user_managed_policy_version = user_managed_policy_details['Policy']['DefaultVersionId']
-            print(Fore.LIGHTBLUE_EX + "    +", user_managed_policy_name + Fore.RESET)
-            print("    + Policy Statement for Managed User Policy:", Fore.LIGHTBLUE_EX + user_managed_policy_name + Fore.RESET)
-            user_managed_policy_doc = client.get_policy_version(PolicyArn=user_managed_policy_arn, VersionId=user_managed_policy_version)
-            for statement in user_managed_policy_doc['PolicyVersion']['Document']['Statement']:
-                for k,v in statement.items():
-                    if k == 'Action':
-                        for action in statement['Action']:
-                            print("              ", k, ":", action)
-                    else:
-                        print("              ", k, ":", v)
-                print("\n", end="")
 
-    #Get user group membership
-    if len(user['GroupList']) == 0:
-        print(Fore.LIGHTGREEN_EX + " - No Group Membership found for", user['UserName'], "\n" + Fore.RESET)
-    else:
-        print(" - User Group Membership: ", user.get('GroupList'))
-        for group in user['GroupList']:
-            for groupname in groupList[0]['GroupDetailList']:
-                if groupname['GroupName'] == group:
-                    print("     - Policies for Group:", Fore.RED + groupname['GroupName'] + Fore.RESET)
-                    
-                    # Inline Group Policies
-                    if len(groupname['GroupPolicyList']) == 0:
-                        print(Fore.LIGHTCYAN_EX + "        - No Inline Policies found"+ Fore.RESET)
-                    else:
-                        print(Fore.LIGHTCYAN_EX + "        - Inline policies: " + Fore.RESET)
-                        for inlinepolicy in groupname['GroupPolicyList']:
-                            inline_policy_name = inlinepolicy.get('PolicyName')
-                            inline_policy_statement = client.get_group_policy(GroupName=group, PolicyName=inline_policy_name)
-                            print(Fore.LIGHTBLUE_EX + "           +", inline_policy_name + Fore.RESET)
-                            print("           + Policy Statement for Inline Policy:" , Fore.LIGHTBLUE_EX + inline_policy_name + Fore.RESET)
-                            # print("           + ", inline_policy_statement['PolicyDocument']['Statement'])
-                            for statement in inline_policy_statement['PolicyDocument']['Statement']:
-                                for k,v in statement.items():
-                                    if k == 'Action':                   #Prints all actions in separate lines
-                                        for action in statement['Action']:
-                                            print("              ", k, ":", action)
-                                    else:
-                                        print("              ", k, ":", v)      #Print all elements within the statement dictionary
-                                print("\n", end="")
-
-                    # Parsing White Space
-                    # Managed Group Policies
-                    if len(groupname['AttachedManagedPolicies']) == 0:
-                        print(Fore.LIGHTCYAN_EX + "        - No Managed Policies found" + Fore.RESET)
-                    else:
-                        print(Fore.LIGHTCYAN_EX + "        - Managed policies:" + Fore.RESET)
-                        for managedpolicy in groupname['AttachedManagedPolicies']:
-                            policy_name = managedpolicy.get('PolicyName')
-                            policy_arn = managedpolicy.get('PolicyArn')
-                            policy_detail = client.get_policy(PolicyArn=policy_arn)
-                            policy_a = policy_detail.get('Policy')
-                            policy_ver = policy_a['DefaultVersionId']
-                            policy_statement = client.get_policy_version(PolicyArn=policy_arn,VersionId=policy_ver)
-                            print("           +", Fore.LIGHTBLUE_EX + policy_name + Fore.RESET)
-                            if policy_name == 'ReadOnlyAccess':
-                                print("           + Policy Statement for Managed Policy \"ReadOnlyAccess\" being skipped (too verbose)\n")
-                            else:   
-                                pass                    
-                                #Uncomment the following and comment the above line if you want to retrieve the managed policy statements. Will result in a lot of data
-                                #### Start commenting from below here
-                                # print("           + Policy Statement for Managed Policy:", Fore.LIGHTBLUE_EX + policy_name + Fore.RESET)
-                                # for statement in policy_statement['PolicyVersion']['Document']['Statement']:
-                                #     for k,v in statement.items():
-                                #         if k == 'Action':                   #Prints all actions in separate lines
-                                #             for action in statement['Action']:
-                                #                 print("              ", k, ":", action)
-                                #         else:
-                                #             print("              ", k, ":", v)      #Print all elements within the statement dictionary
-                                #     print("\n", end="")
-                                ##### Stop commenting
-                else:
-                    pass
-
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-boto3==1.9.14
-botocore==1.12.212
-colorama==0.3.9
+boto3>=1.34.0
+botocore>=1.34.0
+colorama>=0.4.6
+Flask>=3.0.0

--- a/scanner.py
+++ b/scanner.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import boto3
+
+
+@dataclass
+class IAMScanner:
+    profile: str | None = None
+    region: str | None = None
+
+    def __post_init__(self) -> None:
+        session = boto3.Session(profile_name=self.profile, region_name=self.region)
+        self.client = session.client("iam")
+
+    def _paginate(self, operation_name: str, result_key: str, **kwargs: Any) -> list[dict[str, Any]]:
+        """Generic paginator helper that always returns full result sets."""
+        paginator = self.client.get_paginator(operation_name)
+        items: list[dict[str, Any]] = []
+        for page in paginator.paginate(**kwargs):
+            items.extend(page.get(result_key, []))
+        return items
+
+    def _normalize_statements(self, statements: Any) -> list[dict[str, Any]]:
+        if isinstance(statements, dict):
+            return [statements]
+        if isinstance(statements, list):
+            return [s for s in statements if isinstance(s, dict)]
+        return []
+
+    def _extract_actions(self, statement: dict[str, Any]) -> list[str]:
+        actions = statement.get("Action", [])
+        if isinstance(actions, str):
+            return [actions]
+        if isinstance(actions, list):
+            return [str(a) for a in actions]
+        return []
+
+    def _statement_view(self, statement: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "sid": statement.get("Sid"),
+            "effect": statement.get("Effect"),
+            "actions": self._extract_actions(statement),
+            "resource": statement.get("Resource"),
+            "condition": statement.get("Condition"),
+        }
+
+    def scan(self) -> dict[str, Any]:
+        users = self._paginate("get_account_authorization_details", "UserDetailList", Filter=["User"])
+        groups = self._paginate("get_account_authorization_details", "GroupDetailList", Filter=["Group"])
+
+        groups_by_name = {g["GroupName"]: g for g in groups}
+        report_users: list[dict[str, Any]] = []
+
+        for user in users:
+            username = user["UserName"]
+            inline_policy_names = self._paginate("list_user_policies", "PolicyNames", UserName=username)
+
+            inline_policies: list[dict[str, Any]] = []
+            for policy_name in inline_policy_names:
+                policy = self.client.get_user_policy(UserName=username, PolicyName=policy_name)
+                statements = self._normalize_statements(policy["PolicyDocument"].get("Statement"))
+                inline_policies.append(
+                    {
+                        "name": policy_name,
+                        "statements": [self._statement_view(s) for s in statements],
+                    }
+                )
+
+            managed_policies: list[dict[str, Any]] = []
+            for policy in user.get("AttachedManagedPolicies", []):
+                arn = policy["PolicyArn"]
+                detail = self.client.get_policy(PolicyArn=arn)
+                version = detail["Policy"]["DefaultVersionId"]
+                version_doc = self.client.get_policy_version(PolicyArn=arn, VersionId=version)
+                statements = self._normalize_statements(version_doc["PolicyVersion"]["Document"].get("Statement"))
+                managed_policies.append(
+                    {
+                        "name": policy["PolicyName"],
+                        "arn": arn,
+                        "statements": [self._statement_view(s) for s in statements],
+                    }
+                )
+
+            group_membership: list[dict[str, Any]] = []
+            for group_name in user.get("GroupList", []):
+                group = groups_by_name.get(group_name)
+                if not group:
+                    continue
+
+                group_inline: list[dict[str, Any]] = []
+                for inline in group.get("GroupPolicyList", []):
+                    statements = self._normalize_statements(inline["PolicyDocument"].get("Statement"))
+                    group_inline.append(
+                        {
+                            "name": inline.get("PolicyName"),
+                            "statements": [self._statement_view(s) for s in statements],
+                        }
+                    )
+
+                group_managed: list[dict[str, Any]] = []
+                for managed in group.get("AttachedManagedPolicies", []):
+                    arn = managed["PolicyArn"]
+                    detail = self.client.get_policy(PolicyArn=arn)
+                    version = detail["Policy"]["DefaultVersionId"]
+                    version_doc = self.client.get_policy_version(PolicyArn=arn, VersionId=version)
+                    statements = self._normalize_statements(version_doc["PolicyVersion"]["Document"].get("Statement"))
+                    group_managed.append(
+                        {
+                            "name": managed.get("PolicyName"),
+                            "arn": arn,
+                            "statements": [self._statement_view(s) for s in statements],
+                        }
+                    )
+
+                group_membership.append(
+                    {
+                        "name": group_name,
+                        "inline_policies": group_inline,
+                        "managed_policies": group_managed,
+                    }
+                )
+
+            report_users.append(
+                {
+                    "user_name": username,
+                    "inline_policies": inline_policies,
+                    "managed_policies": managed_policies,
+                    "groups": group_membership,
+                }
+            )
+
+        return {"user_count": len(report_users), "users": report_users}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AWS IAM Permissions Scanner</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+  <style>
+    body { background:#f8fafc; }
+    .card { border-radius: 12px; }
+    pre { white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+<div class="container py-5">
+  <h1 class="mb-3">AWS IAM Permissions Scanner</h1>
+  <p class="text-muted">Scan IAM users, policies, and group permissions from a simple web UI.</p>
+
+  <div class="card p-4 mb-4">
+    <form method="post" class="row g-3 align-items-end">
+      <div class="col-md-6">
+        <label for="profile" class="form-label">AWS Profile (optional)</label>
+        <input id="profile" name="profile" class="form-control" value="{{ profile }}" placeholder="default" />
+      </div>
+      <div class="col-md-3">
+        <button class="btn btn-primary w-100" type="submit">Run Scan</button>
+      </div>
+    </form>
+  </div>
+
+  {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+
+  {% if report %}
+    <div class="alert alert-success">Scanned {{ report.user_count }} users.</div>
+    {% for user in report.users %}
+      <div class="card p-3 mb-3">
+        <h5>{{ user.user_name }}</h5>
+        <div class="row">
+          <div class="col-md-4">
+            <h6>Inline Policies</h6>
+            <ul>
+              {% for policy in user.inline_policies %}
+                <li>{{ policy.name }}</li>
+              {% else %}
+                <li class="text-muted">None</li>
+              {% endfor %}
+            </ul>
+          </div>
+          <div class="col-md-4">
+            <h6>Managed Policies</h6>
+            <ul>
+              {% for policy in user.managed_policies %}
+                <li>{{ policy.name }}</li>
+              {% else %}
+                <li class="text-muted">None</li>
+              {% endfor %}
+            </ul>
+          </div>
+          <div class="col-md-4">
+            <h6>Groups</h6>
+            <ul>
+              {% for group in user.groups %}
+                <li>{{ group.name }}</li>
+              {% else %}
+                <li class="text-muted">None</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+    {% endfor %}
+  {% endif %}
+</div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace fragile single-page IAM listing with a robust scanner that fully handles AWS paginator responses for user, group and inline policy collections.
- Make the scanner reusable from multiple frontends so outputs can be consumed by both CLI and a web UI.
- Provide a simple browser-based interface so operators can run scans without using the CLI.

### Description
- Introduce `scanner.py` which implements a reusable `IAMScanner` class, a generic `_paginate` helper, statement normalization, and action extraction so full paginated results are collected and normalized.
- Replace the old monolithic script with `aws_perms.py` that uses `IAMScanner`, adds CLI flags `--profile`, `--region`, and `--json`, and prints a compact human-readable or JSON report.
- Add a Flask web app in `app.py` and a Bootstrap template `templates/index.html` to run scans from a browser and present users, inline/managed policies, and group membership.
- Update `README.md` and `requirements.txt` to document the changes and list updated dependency bounds (`boto3`, `botocore`, `colorama`, and `Flask`).

### Testing
- Ran `python -m py_compile aws_perms.py scanner.py app.py` and it completed successfully.
- Attempted `pip3 install -r requirements.txt` but it failed in this environment due to network/proxy restrictions against the package index.
- A basic web-render test using Flask's test client could not be run here because `flask` could not be installed for the same network reason.
- No automated unit tests were added; manual compile checks were performed as noted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baac9d3c508331bdf1e4bba0dee818)